### PR TITLE
Add configuration for Darwin

### DIFF
--- a/config/Makefile.darwin
+++ b/config/Makefile.darwin
@@ -1,0 +1,7 @@
+ARFLAGS = crs
+
+LIB.STATIC = lib$(LIB.NAME).a
+LIB.HEADERS += clens/readpassphrase.h clens/glob.h clens/sys/tree.h
+LIB.HEADERS += clens/sys/queue.h
+LIB.HDRDIRS += clens/sys
+SRCS+= fmt_scaled.c fgetln.c fparseln.c

--- a/include/clens/clens.h
+++ b/include/clens/clens.h
@@ -94,6 +94,21 @@ void		 clens_version(int *major, int *minor, int *patch);
 
 #endif /* __linux__ || __CYGWIN__ */
 
+#ifdef __APPLE__
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NEED_ARC4RANDOM_BUF
+#define NEED_ARC4RANDOM_UNIFORM
+#define NEED_STRNVIS
+#define NEED_STRNUNVIS
+#define NEED_FMT_SCALED
+#define NEED_FGETLN
+#define NEED_FPARSELN
+#define NEED_STRTONUM
+#endif /* __APPLE__ */
+
 #ifndef timespeccmp
 #define	timespeccmp(tsp, usp, cmp)					\
 	(((tsp)->tv_sec == (usp)->tv_sec) ?				\


### PR DESCRIPTION
Since the new portable mg snapshot depends on clens, here is the needed configuration to get mg building on Darwin.

This was tested on 10.8.5 with: 

```
Apple LLVM version 4.2 (clang-425.0.24) (based on LLVM 3.2svn)
Target: x86_64-apple-darwin12.5.0
Thread model: posix
```
